### PR TITLE
[app][feat] populate metsHdr section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,111 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.mycore</groupId>
-    <artifactId>mycore-parent</artifactId>
-    <version>43</version>
-  </parent>
-  <groupId>org.mycore.mets</groupId>
-  <artifactId>mets-model</artifactId>
-  <version>2.0</version>
-  <packaging>jar</packaging>
-  <name>Mets Model</name>
-  <issueManagement>
-    <system>GitHub</system>
-    <url>https://github.com/MyCoRe-Org/mets-model/issues</url>
-  </issueManagement>
-  <scm>
-    <connection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</connection>
-    <developerConnection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</developerConnection>
-    <url>https://github.com/MyCoRe-Org/mets-model</url>
-    <tag>v2.0</tag>
-  </scm>
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-  </repositories>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.12.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom2</artifactId>
-      <version>2.0.6</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <developers>
-    <developer>
-      <id>mcrmeich</id>
-      <name>Matthias Eichner</name>
-      <email>matthias.eichner (at) uni-jena.de</email>
-      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>mcrsherm</id>
-      <name>Silvio Hermann</name>
-      <email>s.hermann (at) uni-jena.de</email>
-      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>mcrshofm</id>
-      <name>Sebastian Hofmann</name>
-      <email>vo62xat (at) uni-jena.de</email>
-      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>mcrtchef</id>
-      <name>Thomas Scheffler</name>
-      <email>thomas.scheffler (at) uni-jena.de</email>
-      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>mcrvuchi</id>
-      <name>Hu Chi Vu</name>
-      <email>chi (at) thulb.uni-jena.de</email>
-      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-  </developers>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.mycore</groupId>
+		<artifactId>mycore-parent</artifactId>
+		<version>43</version>
+	</parent>
+	<groupId>org.mycore.mets</groupId>
+	<artifactId>mets-model</artifactId>
+	<version>2.0</version>
+	<packaging>jar</packaging>
+	<name>Mets Model</name>
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/MyCoRe-Org/mets-model/issues</url>
+	</issueManagement>
+	<scm>
+		<connection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</connection>
+		<developerConnection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</developerConnection>
+		<url>https://github.com/MyCoRe-Org/mets-model</url>
+		<tag>v2.0</tag>
+	</scm>
+	<repositories>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</repository>
+	</repositories>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.12.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom2</artifactId>
+			<version>2.0.6</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jaxen</groupId>
+			<artifactId>jaxen</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<developers>
+		<developer>
+			<id>mcrmeich</id>
+			<name>Matthias Eichner</name>
+			<email>matthias.eichner (at) uni-jena.de</email>
+			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>mcrsherm</id>
+			<name>Silvio Hermann</name>
+			<email>s.hermann (at) uni-jena.de</email>
+			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>mcrshofm</id>
+			<name>Sebastian Hofmann</name>
+			<email>vo62xat (at) uni-jena.de</email>
+			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>mcrtchef</id>
+			<name>Thomas Scheffler</name>
+			<email>thomas.scheffler (at) uni-jena.de</email>
+			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>mcrvuchi</id>
+			<name>Hu Chi Vu</name>
+			<email>chi (at) thulb.uni-jena.de</email>
+			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+	</developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,119 +1,111 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.mycore</groupId>
-		<artifactId>mycore-parent</artifactId>
-		<version>43</version>
-	</parent>
-	<groupId>org.mycore.mets</groupId>
-	<artifactId>mets-model</artifactId>
-	<version>2.0</version>
-	<packaging>jar</packaging>
-	<name>Mets Model</name>
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/MyCoRe-Org/mets-model/issues</url>
-	</issueManagement>
-	<scm>
-		<connection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</connection>
-		<developerConnection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</developerConnection>
-		<url>https://github.com/MyCoRe-Org/mets-model</url>
-		<tag>v2.0</tag>
-	</scm>
-	<repositories>
-		<repository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</repository>
-	</repositories>
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.12.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jdom</groupId>
-			<artifactId>jdom2</artifactId>
-			<version>2.0.6</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-			<version>1.2.0</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<developers>
-		<developer>
-			<id>mcrmeich</id>
-			<name>Matthias Eichner</name>
-			<email>matthias.eichner (at) uni-jena.de</email>
-			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>+1</timezone>
-		</developer>
-		<developer>
-			<id>mcrsherm</id>
-			<name>Silvio Hermann</name>
-			<email>s.hermann (at) uni-jena.de</email>
-			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>+1</timezone>
-		</developer>
-		<developer>
-			<id>mcrshofm</id>
-			<name>Sebastian Hofmann</name>
-			<email>vo62xat (at) uni-jena.de</email>
-			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>+1</timezone>
-		</developer>
-		<developer>
-			<id>mcrtchef</id>
-			<name>Thomas Scheffler</name>
-			<email>thomas.scheffler (at) uni-jena.de</email>
-			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>+1</timezone>
-		</developer>
-		<developer>
-			<id>mcrvuchi</id>
-			<name>Hu Chi Vu</name>
-			<email>chi (at) thulb.uni-jena.de</email>
-			<organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
-			<organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>+1</timezone>
-		</developer>
-	</developers>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.mycore</groupId>
+    <artifactId>mycore-parent</artifactId>
+    <version>44-SNAPSHOT</version>
+  </parent>
+  <groupId>org.mycore.mets</groupId>
+  <artifactId>mets-model</artifactId>
+  <version>2.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Mets Model</name>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/MyCoRe-Org/mets-model/issues</url>
+  </issueManagement>
+  <scm>
+    <connection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</connection>
+    <developerConnection>scm:git:https://github.com/MyCoRe-Org/mets-model.git</developerConnection>
+    <url>https://github.com/MyCoRe-Org/mets-model</url>
+    <tag>HEAD</tag>
+  </scm>
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <developers>
+    <developer>
+      <id>mcrmeich</id>
+      <name>Matthias Eichner</name>
+      <email>matthias.eichner (at) uni-jena.de</email>
+      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>mcrsherm</id>
+      <name>Silvio Hermann</name>
+      <email>s.hermann (at) uni-jena.de</email>
+      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>mcrshofm</id>
+      <name>Sebastian Hofmann</name>
+      <email>vo62xat (at) uni-jena.de</email>
+      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>mcrtchef</id>
+      <name>Thomas Scheffler</name>
+      <email>thomas.scheffler (at) uni-jena.de</email>
+      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+    <developer>
+      <id>mcrvuchi</id>
+      <name>Hu Chi Vu</name>
+      <email>chi (at) thulb.uni-jena.de</email>
+      <organization>Friedrich-Schiller-Universität Jena, Thüringer Universitäts- und Landesbibliothek</organization>
+      <organizationUrl>http://www.thulb.uni-jena.de/</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>+1</timezone>
+    </developer>
+  </developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jaxen</groupId>
+      <artifactId>jaxen</artifactId>
+      <version>1.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.mycore</groupId>
     <artifactId>mycore-parent</artifactId>
-    <version>44-SNAPSHOT</version>
+    <version>45</version>
   </parent>
   <groupId>org.mycore.mets</groupId>
   <artifactId>mets-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@
       <version>2.0.6</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
       <version>1.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/mycore/mets/model/Mets.java
+++ b/src/main/java/org/mycore/mets/model/Mets.java
@@ -21,6 +21,8 @@ package org.mycore.mets.model;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -52,7 +54,10 @@ import org.mycore.mets.model.files.FLocat;
 import org.mycore.mets.model.files.File;
 import org.mycore.mets.model.files.FileGrp;
 import org.mycore.mets.model.files.FileSec;
+import org.mycore.mets.model.header.Agent;
 import org.mycore.mets.model.header.MetsHdr;
+import org.mycore.mets.model.header.Name;
+import org.mycore.mets.model.header.Note;
 import org.mycore.mets.model.sections.AmdSec;
 import org.mycore.mets.model.sections.DmdSec;
 import org.mycore.mets.model.sections.MdWrapSection;
@@ -80,611 +85,657 @@ import org.xml.sax.SAXException;
  */
 public class Mets {
 
-    // thread-safe
-    private static final XPathFactory XPATH_FACTORY = XPathFactory.instance();
-
-    // thread-safe
-    private static final Logger LOGGER = LogManager.getLogger();
-
-    // thread-safe
-    private static Schema SCHEMA;
-
-    private Map<String, DmdSec> dmdsecs;
-
-    private Map<String, AmdSec> amdsecs;
-
-    private Map<String, IStructMap> structMaps;
-
-    private StructLink structLink;
-
-    private FileSec fileSec;
-
-    private MetsHdr metsHdr;
-
-    static {
-        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Source metsSchemaSource;
-        try {
-            CatalogResolver catalogResolver = getCatalogResolver();
-            schemaFactory.setResourceResolver(catalogResolver);
-            metsSchemaSource = getMetsSchema(catalogResolver);
-            LOGGER.info("Loading METS XML Schema from: {}", metsSchemaSource.getSystemId());
-            SCHEMA = schemaFactory.newSchema(metsSchemaSource);
-        } catch (SAXException | IOException e) {
-            LOGGER.error("Could not load METS XML Schema.", e);
-        }
-    }
-
-    public Mets() {
-        this.dmdsecs = new LinkedHashMap<>();
-        this.amdsecs = new LinkedHashMap<>();
-        this.structMaps = new LinkedHashMap<>();
-        this.structMaps.put(PhysicalStructMap.TYPE, new PhysicalStructMap());
-        this.structMaps.put(LogicalStructMap.TYPE, new LogicalStructMap());
-        this.fileSec = new FileSec();
-        this.structLink = new StructLink();
-        this.metsHdr = null;
-    }
-
-    /**
-     * Creates a {@link Mets} object from the given {@link Document} object.
-     *
-     * @param source the source document
-     */
-    public Mets(Document source) {
-        if (!Mets.isValid(source)) {
-            throw new IllegalArgumentException("The given document is not a valid mets document");
-        }
-        this.dmdsecs = createDmdSec(source);
-        this.amdsecs = createAmdSec(source);
-        this.fileSec = createFileSec(source);
-        this.structMaps = new HashMap<>();
-        this.structMaps.put(LogicalStructMap.TYPE, createLogicalStructMap(source));
-        this.structMaps.put(PhysicalStructMap.TYPE, createPhysicalStructMap(source));
-        this.structLink = createStuctLinks(source);
-    }
-
-    private static Source getMetsSchema(CatalogResolver catalogResolver) throws SAXException, IOException {
-        InputSource resolvedSchema = catalogResolver.resolveEntity(null, "http://www.loc.gov/standards/mets/mets.xsd");
-        return new StreamSource(resolvedSchema.getSystemId());
-    }
-
-    private static CatalogResolver getCatalogResolver() throws IOException {
-        Enumeration<URL> resources = Mets.class.getClassLoader().getResources("catalog.xml");
-        URI[] catalogURIs = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(resources.asIterator(), Spliterator.ORDERED), false)
-            .map(URL::toString)
-            .peek(s -> LOGGER.info("Using XML catalog: {}", s))
-            .map(URI::create)
-            .toArray(URI[]::new);
-        return CatalogManager.catalogResolver(CatalogFeatures.defaults(), catalogURIs);
-    }
-
-    public static Map<String, DmdSec> createDmdSec(Document source) {
-        Map<String, DmdSec> dmdsecs = new HashMap<>();
-        XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:dmdSec");
-
-        for (Element section : xp.evaluate(source)) {
-            DmdSec dmdSec = new DmdSec(section.getAttributeValue("ID"));
-            dmdsecs.put(dmdSec.getId(), dmdSec);
-
-            // handle mdWrap
-            xp = getXpathExpression("mets:mdWrap");
-
-            for (Element wrap : xp.evaluate(section)) {
-                XPathExpression<Element> xmlDataXP = getXpathExpression("mets:xmlData/*");
-                Element element = xmlDataXP.evaluateFirst(wrap);
-                MdWrap mdWrap = new MdWrap(MdWrapSection.findTypeByName(wrap.getAttributeValue("MDTYPE")),
-                    (Element) element.clone());
-                dmdSec.setMdWrap(mdWrap);
-            }
-
-            // handle mdRef
-            xp = getXpathExpression("mets:mdRef");
-
-            for (Element refElem : xp.evaluate(section)) {
-                LOCTYPE loctype = LOCTYPE.valueOf(refElem.getAttributeValue("LOCTYPE"));
-                String mimetype = refElem.getAttributeValue("MIMETYPE");
-                MDTYPE mdtype = MdWrapSection.findTypeByName(refElem.getAttributeValue("MDTYPE"));
-                String href = refElem.getAttributeValue("href", IMetsElement.XLINK);
-                MdRef mdRef = new MdRef(href, loctype, mimetype, mdtype, refElem.getText());
-                dmdSec.setMdRef(mdRef);
-            }
-        }
-        return dmdsecs;
-    }
-
-    public static Map<String, AmdSec> createAmdSec(Document source) {
-        Map<String, AmdSec> amdsecs = new HashMap<>();
-        XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:amdSec");
-
-        for (Element section : xp.evaluate(source)) {
-            AmdSec amdSec = new AmdSec(section.getAttributeValue("ID"));
-            amdsecs.put(amdSec.getId(), amdSec);
-
-            addOther(section, amdSec, "rightsMD");
-            addOther(section, amdSec, "digiprovMD");
-        }
-        return amdsecs;
-    }
-
-    /**
-     * Creates the elements embedded in the mets:amdSec. Currently the
-     * mets:rightsMD and the mets:digiprovMD sections are supported.
-     *
-     * @param section
-     * @param amdSec
-     * @param flag
-     *            one of "rightsMD" or "addRightsMd"
-     */
-    private static void addOther(Element section, AmdSec amdSec, String flag) {
-        XPathExpression<Element> rightsMdXP = getXpathExpression("mets:" + flag);
-
-        Element flagElement = rightsMdXP.evaluateFirst(section);
-        if (flagElement != null) {
-            String id = flagElement.getAttributeValue("ID");
-            RightsMD rightsMd = new RightsMD(id);
-            amdSec.setRightsMD(rightsMd);
-
-            XPathExpression<Element> mdWrapXP = getXpathExpression("mets:mdWrap");
-
-            flagElement = mdWrapXP.evaluateFirst(flagElement);
-            if (flagElement != null) {
-                String name = flagElement.getAttributeValue("MDTYPE");
-                XPathExpression<Element> xmlDataXP = getXpathExpression("mets:xmlData/*");
-                Element element = xmlDataXP.evaluateFirst(flagElement);
-                MdWrap mdWrap = new MdWrap(MdWrapSection.findTypeByName(name), (Element) element.clone());
-                mdWrap.setOtherMdType(flagElement.getAttributeValue("OTHERMDTYPE"));
-                rightsMd.setMdWrap(mdWrap);
-            }
-        }
-    }
-
-    /**
-     * Creates the mets:structMap TYPE="LOGICAL".
-     *
-     * @param source the source document
-     * @return a new created logical struct map based on the source
-     */
-    public static LogicalStructMap createLogicalStructMap(Document source) {
-        LogicalStructMap logicalStructMap = new LogicalStructMap();
-        XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:structMap[@TYPE='LOGICAL']/mets:div");
-
-        Element logDivContainerElem = xp.evaluateFirst(source);
-
-        LogicalDiv logDivContainer = new LogicalDiv(logDivContainerElem.getAttributeValue("ID"),
-            logDivContainerElem.getAttributeValue("TYPE"), logDivContainerElem.getAttributeValue("LABEL"),
-            logDivContainerElem.getAttributeValue("ADMID"), logDivContainerElem.getAttributeValue("DMDID"));
-
-        for (Element logSubDiv : logDivContainerElem.getChildren()) {
-            LogicalDiv lsd = new LogicalDiv(logSubDiv.getAttributeValue("ID"), logSubDiv.getAttributeValue("TYPE"),
-                logSubDiv.getAttributeValue("LABEL"));
-            logDivContainer.add(lsd);
-
-            processLogicalChildren(logSubDiv.getChildren(), lsd);
-        }
-
-        // add the div container to the struct map
-        logicalStructMap.setDivContainer(logDivContainer);
-        return logicalStructMap;
-    }
-
-    /**
-     * @param children
-     * @param parent
-     */
-    private static void processLogicalChildren(List<Element> children, LogicalDiv parent) {
-        for (Element child : children) {
-            switch (child.getName()) {
-                case "fptr":
-                    Fptr fptr = processFPTR(child);
-                    parent.getFptrList().add(fptr);
-                    break;
-                case "div":
-                    LogicalDiv lsd = new LogicalDiv(child.getAttributeValue("ID"),
-                        child.getAttributeValue("TYPE"),
-                        child.getAttributeValue("LABEL"));
-                    parent.add(lsd);
-
-                    processLogicalChildren((List<Element>) child.getChildren(), lsd);
-                    break;
-                default:
-                    return;
-            }
-        }
-    }
-
-    private static Fptr processFPTR(Element child) {
-        Fptr fptr = new Fptr();
-
-        String fileid = child.getAttributeValue("FILEID");
-        if (fileid != null) {
-            fptr.setFileId(fileid);
-        }
-
-        Element seq = child.getChild("seq", IMetsElement.METS);
-        if (seq != null) {
-            Seq newSEQ = new Seq();
-            fptr.getSeqList().add(newSEQ);
-
-            List<Element> seqAreaChildren = seq.getChildren("area", IMetsElement.METS);
-            for (Element area : seqAreaChildren) {
-                String fileId = area.getAttributeValue("FILEID");
-                if (fileId == null) {
-                    throw new IllegalArgumentException("FILEID attribute value of mets:area must not be null");
-                }
-                String betype = area.getAttributeValue("BETYPE");
-                String begin = area.getAttributeValue("BEGIN");
-                String end = area.getAttributeValue("END");
-                newSEQ.getAreaList().add(new Area(fileId, betype, begin, end));
-            }
-        }
-        return fptr;
-    }
-
-    /**
-     * Creates the mets:structMap TYPE="PHYSICAL".
-     *
-     * @param source the source document
-     * @return a new created physical struct map based on the given source
-     */
-    public static PhysicalStructMap createPhysicalStructMap(Document source) {
-        PhysicalStructMap structMap = new PhysicalStructMap();
-        XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:structMap[@TYPE='PHYSICAL']/mets:div");
-
-        Element physDivElem = xp.evaluateFirst(source);
-        String id = physDivElem.getAttributeValue("ID");
-        String type = physDivElem.getAttributeValue("TYPE");
-
-        if (id == null || type == null) {
-            throw new IllegalArgumentException("ID and TYPE attribute of mets:div must not be null");
-        }
-        PhysicalDiv physDivContainer = new PhysicalDiv(id, type);
-        structMap.setDivContainer(physDivContainer);
-
-        for (Element subDiv : physDivElem.getChildren()) {
-            PhysicalSubDiv psd = new PhysicalSubDiv(subDiv.getAttributeValue("ID"), subDiv.getAttributeValue("TYPE"));
-
-            String orderLabel = subDiv.getAttributeValue("ORDERLABEL");
-            if (orderLabel != null) {
-                psd.setOrderLabel(orderLabel);
-            }
-
-            String contentIDs = subDiv.getAttributeValue("CONTENTIDS");
-            if (contentIDs != null) {
-                psd.setContentIds(contentIDs);
-            }
-
-            xp = getXpathExpression("./mets:fptr");
-
-            for (Element fptrElem : xp.evaluate(subDiv)) {
-                Fptr fptr = new Fptr(fptrElem.getAttributeValue("FILEID"));
-                psd.add(fptr);
-            }
-            physDivContainer.add(psd);
-        }
-        return structMap;
-    }
-
-    /**
-     * Creates the mets:structLink section from the given source.
-     *
-     * @param source the source document
-     * @return a new created struct link based on the given source
-     */
-    public static StructLink createStuctLinks(Document source) {
-        StructLink structLink = new StructLink();
-        XPathExpression<Element> smLinksXP = getXpathExpression("mets:mets/mets:structLink/mets:smLink");
-
-        for (Element smLink : smLinksXP.evaluate(source)) {
-            String from = smLink.getAttributeValue("from", IMetsElement.XLINK);
-            String to = smLink.getAttributeValue("to", IMetsElement.XLINK);
-            if (from == null || to == null) {
-                throw new IllegalArgumentException("xlink:from and xlink:to must not be null in mets:smLink element");
-            }
-            SmLink l = new SmLink(from, to);
-            structLink.addSmLink(l);
-        }
-        return structLink;
-    }
-
-    private static XPathExpression<Element> getXpathExpression(String xpath) {
-        return XPATH_FACTORY.compile(xpath, Filters.element(), null, IMetsElement.METS);
-    }
-
-    /**
-     * Creates the file section from the given source document.
-     *
-     * @param source the source document
-     * @return a new created file section based on the given source
-     */
-    public static FileSec createFileSec(Document source) {
-        FileSec fileSec = new FileSec();
-        XPathExpression<Element> grpXPath = getXpathExpression("mets:mets/mets:fileSec/mets:fileGrp");
-
-        for (Element aFileGroup : grpXPath.evaluate(source)) {
-            // create a fileGrp object
-            String useAttribute = aFileGroup.getAttributeValue("USE");
-            if (useAttribute == null) {
-                throw new IllegalArgumentException("USE attribute value must not be null");
-            }
-            FileGrp grp = new FileGrp(useAttribute);
-
-            // get the files to add to the file grp object
-            XPathExpression<Element> filesXP = getXpathExpression("./mets:file");
-
-            for (Element aFile : filesXP.evaluate(aFileGroup)) {
-                String id = aFile.getAttributeValue("ID");
-                String mimeType = aFile.getAttributeValue("MIMETYPE");
-                if (id == null || mimeType == null) {
-                    throw new IllegalArgumentException("MIMETYPE or ID of a mets:file must not be null");
-                }
-                File f = new File(id, mimeType);
-                // create the FLocat element and add it to the file element
-                String locType = aFile.getChild("FLocat", IMetsElement.METS).getAttributeValue("LOCTYPE");
-                String href = aFile.getChild("FLocat", IMetsElement.METS).getAttributeValue("href", IMetsElement.XLINK);
-
-                if (locType == null || href == null) {
-                    throw new IllegalArgumentException("LOCTYPE or xlink:href of a mets:FLocat must not be null");
-                }
-                FLocat fLoc = new FLocat(LOCTYPE.valueOf(locType), href);
-                f.setFLocat(fLoc);
-                grp.addFile(f);
-            }
-
-            //add the new created file group to the file section
-            fileSec.addFileGrp(grp);
-        }
-        return fileSec;
-    }
-
-    /**
-     * Sets the header for this document.
-     * 
-     * @param metsHdr
-     *            the mets header
-     */
-    public void setMetsHdr(MetsHdr metsHdr) {
-        this.metsHdr = metsHdr;
-    }
-
-    /**
-     * Returns the header for this mets document.
-     * Can return null if no header is specified.
-     * 
-     * @return the mets header or null
-     */
-    public MetsHdr getMetsHdr() {
-        return metsHdr;
-    }
-
-    /**
-     * Adds the section to the mets document
-     *
-     * @param section
-     *            the section to add
-     * @return <code>true</code> if the section was added successfully,
-     *         <code>false</code> otherwise
-     */
-    public boolean addDmdSec(DmdSec section) {
-        String id = section.getId();
-        if (dmdsecs.containsKey(id)) {
-            return false;
-        }
-        dmdsecs.put(id, section);
-        return true;
-    }
-
-    /**
-     * Removes the given MdSection from the Mets document
-     *
-     * @param section the section to remove
-     */
-    public void removeDmdSec(DmdSec section) {
-        dmdsecs.remove(section.getId());
-    }
-
-    /**
-     * Removes all dmd sections from the mets document.
-     */
-    public void clearDmdSecs() {
-        dmdsecs.clear();
-    }
-
-    /**
-     * Adds the section to the mets document
-     *
-     * @param section
-     *            the section to add
-     * @return <code>true</code> if the section was added successfully,
-     *         <code>false</code> otherwise
-     */
-    public boolean addAmdSec(AmdSec section) {
-        String id = section.getId();
-        if (amdsecs.containsKey(id)) {
-            return false;
-        }
-        amdsecs.put(id, section);
-        return true;
-    }
-
-    /**
-     * Removes the given MdSection from the Mets document
-     *
-     * @param section the section to remove
-     */
-    public void removeAmdSec(AmdSec section) {
-        amdsecs.remove(section.getId());
-    }
-
-    /**
-     * Removes all amd sections from the mets document.
-     */
-    public void clearAmdSec() {
-        amdsecs.clear();
-    }
-
-    public IStructMap getStructMap(String type) {
-        return this.structMaps.get(type);
-    }
-
-    public PhysicalStructMap getPhysicalStructMap() {
-        return (PhysicalStructMap) this.structMaps.get(PhysicalStructMap.TYPE);
-    }
-
-    public LogicalStructMap getLogicalStructMap() {
-        return (LogicalStructMap) this.structMaps.get(LogicalStructMap.TYPE);
-    }
-
-    public void addStructMap(IStructMap structMap) {
-        this.structMaps.put(structMap.getType(), structMap);
-    }
-
-    public void removeStructMap(String type) {
-        this.structMaps.remove(type);
-    }
-
-    /**
-     * @return the structLink
-     */
-    public StructLink getStructLink() {
-        return structLink;
-    }
-
-    /**
-     * @param structLink
-     *            the structLink to set
-     */
-    public void setStructLink(StructLink structLink) {
-        this.structLink = structLink;
-    }
-
-    /**
-     * @return the fileSec
-     */
-    public FileSec getFileSec() {
-        return fileSec;
-    }
-
-    /**
-     * @param fileSec
-     *            the fileSec to set
-     */
-    public void setFileSec(FileSec fileSec) {
-        this.fileSec = fileSec;
-    }
-
-    /**
-     * @param id
-     *            the id of the amdsec to retrieve
-     * @return the amdsec with the given id or null if there is no such amd
-     *         section
-     */
-    public AmdSec getAmdSecById(String id) {
-        return this.amdsecs.get(id);
-    }
-
-    /**
-     * @return all amd sections
-     */
-    public AmdSec[] getAmdSections() {
-        return this.amdsecs.values().toArray(new AmdSec[0]);
-    }
-
-    /**
-     * @return all dmd sections
-     */
-    public DmdSec[] getDmdSections() {
-        return this.dmdsecs.values().toArray(new DmdSec[0]);
-    }
-
-    /**
-     * @param id
-     *            the id of the dmdsec to retrieve
-     * @return the dmdsec with the given id or null if there is no such dmd
-     *         section
-     */
-    public DmdSec getDmdSecById(String id) {
-        return this.dmdsecs.get(id);
-    }
-
-    /**
-     * Returns the Mets Object as {@link Document}.
-     *
-     * @return the mets object as jdom document
-     */
-    public Document asDocument() {
-        Document doc = new Document();
-        doc.setRootElement(asElement());
-        return doc;
-    }
-
-    /**
-     * Returns the Mets Object as {@link Element}
-     *
-     * @return the mets object as jdom element
-     */
-    public Element asElement() {
-        Element mets = new Element("mets", IMetsElement.METS);
-        mets.addNamespaceDeclaration(IMetsElement.XSI);
-        mets.setAttribute("schemaLocation", IMetsElement.SCHEMA_LOC_METS, IMetsElement.XSI);
-
-        if (this.metsHdr != null) {
-            mets.addContent(this.metsHdr.asElement());
-        }
-        for (DmdSec dmdSec : this.dmdsecs.values()) {
-            mets.addContent(dmdSec.asElement());
-        }
-
-        for (AmdSec amdSec : this.amdsecs.values()) {
-            mets.addContent(amdSec.asElement());
-        }
-        if (this.getFileSec() != null) {
-            mets.addContent(this.getFileSec().asElement());
-        }
-        for (IStructMap sM : this.structMaps.values()) {
-            mets.addContent(sM.asElement());
-        }
-        if (this.getStructLink() != null) {
-            mets.addContent(this.getStructLink().asElement());
-        }
-        return mets;
-    }
-
-    /**
-     * @param doc
-     *            the document to validate against the mets schema
-     * @return true if the document is a valid mets document false otherwise
-     */
-    public static boolean isValid(Document doc) {
-        Validator validator = SCHEMA.newValidator();
-        try {
-            validator.validate(new JDOMSource(doc));
-            return true;
-        } catch (SAXException saxEx) {
-            LOGGER.error("Error parsing and validating mets document", saxEx);
-        } catch (IOException ioEx) {
-            LOGGER.error("Error reading input stream", ioEx);
-        }
-        return false;
-    }
-
-    /**
-     * Validates the mets object.
-     * 
-     * @return <code>true</code> if the underlying mets document ist valid,
-     *         <code>false</code> otherwise
-     */
-    final public boolean isValid() {
-        Document doc;
-        try {
-            doc = this.asDocument();
-        } catch (Throwable t) {
-            LOGGER.error("Error occured while validating mets document", t);
-            return false;
-        }
-
-        return Mets.isValid(doc);
-    }
+	// thread-safe
+	private static final XPathFactory XPATH_FACTORY = XPathFactory.instance();
+
+	// thread-safe
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	// thread-safe
+	private static Schema SCHEMA;
+
+	private Map<String, DmdSec> dmdsecs;
+
+	private Map<String, AmdSec> amdsecs;
+
+	private Map<String, IStructMap> structMaps;
+
+	private StructLink structLink;
+
+	private FileSec fileSec;
+
+	private MetsHdr metsHdr;
+
+	static {
+		SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+		Source metsSchemaSource;
+		try {
+			CatalogResolver catalogResolver = getCatalogResolver();
+			schemaFactory.setResourceResolver(catalogResolver);
+			metsSchemaSource = getMetsSchema(catalogResolver);
+			LOGGER.info("Loading METS XML Schema from: {}", metsSchemaSource.getSystemId());
+			SCHEMA = schemaFactory.newSchema(metsSchemaSource);
+		} catch (SAXException | IOException e) {
+			LOGGER.error("Could not load METS XML Schema.", e);
+		}
+	}
+
+	public Mets() {
+		this.dmdsecs = new LinkedHashMap<>();
+		this.amdsecs = new LinkedHashMap<>();
+		this.structMaps = new LinkedHashMap<>();
+		this.structMaps.put(PhysicalStructMap.TYPE, new PhysicalStructMap());
+		this.structMaps.put(LogicalStructMap.TYPE, new LogicalStructMap());
+		this.fileSec = new FileSec();
+		this.structLink = new StructLink();
+		this.metsHdr = new MetsHdr();
+	}
+
+	/**
+	 * Creates a {@link Mets} object from the given {@link Document} object.
+	 *
+	 * @param source the source document
+	 */
+	public Mets(Document source) {
+		if (!Mets.isValid(source)) {
+			throw new IllegalArgumentException("The given document is not a valid mets document");
+		}
+		this.dmdsecs = createDmdSec(source);
+		this.amdsecs = createAmdSec(source);
+		this.fileSec = createFileSec(source);
+		this.structMaps = new HashMap<>();
+		this.structMaps.put(LogicalStructMap.TYPE, createLogicalStructMap(source));
+		this.structMaps.put(PhysicalStructMap.TYPE, createPhysicalStructMap(source));
+		this.structLink = createStuctLinks(source);
+		this.metsHdr = createMetsHdr(source);
+	}
+
+	public static MetsHdr createMetsHdr(Document source) {
+		XPathExpression<Element> metsHdrXP = getXpathExpression("mets:mets/mets:metsHdr");
+		Element metsHdrElement = metsHdrXP.evaluate(source).get(0);
+		MetsHdr metsHdr = new MetsHdr();
+
+		String strCreateDate = metsHdrElement.getAttributeValue("CREATEDATE");
+		if (strCreateDate != null) {
+			LocalDateTime localDateTime = LocalDateTime.parse(strCreateDate);
+			metsHdr.setCreateDate(localDateTime);
+		}
+		String strModifiedDate = metsHdrElement.getAttributeValue("LASTMODDATE");
+		if(strModifiedDate != null) {
+			LocalDateTime localDateTime = LocalDateTime.parse(strModifiedDate);
+			metsHdr.setLastModDate(localDateTime);
+		}
+
+		XPathExpression<Element> agentXP = getXpathExpression("mets:mets/mets:metsHdr/mets:agent");
+		List<Agent> agents = new ArrayList<>();
+		for (Element element : agentXP.evaluate(source)) {
+			Agent agent = new Agent();
+			String role = element.getAttributeValue("ROLE");
+			String otherRole = element.getAttributeValue("OTHERROLE");
+			String type = element.getAttributeValue("TYPE");
+			String otherType = element.getAttributeValue("OTHERTYPE");
+			String id = element.getAttributeValue("ID");
+			if (role != null) {
+				agent.setRole(role);
+			}
+			if (otherRole != null) {
+				agent.setOtherRole(otherRole);
+			}
+			if (type != null) {
+				agent.setType(type);
+			}
+			if (otherType != null) {
+				agent.setOtherType(otherType);
+			}
+			if (id != null) {
+				agent.setId(id);
+			}
+			Element elementName = element.getChild("name", IMetsElement.METS);
+			if (elementName != null) {
+				Name name = new Name(elementName.getTextNormalize());
+				agent.setName(name);
+			}
+			XPathExpression<Element> agentNotesXP = getXpathExpression("mets:mets/mets:metsHdr/mets:agent/mets:note");
+			List<Note> notes = new ArrayList<>();
+			for (Element elementNote : agentNotesXP.evaluate(source)) {
+				Note note = new Note(elementNote.getTextNormalize());
+				notes.add(note);
+			}
+			if (!notes.isEmpty()) {
+				agent.setNotes(notes);
+			}
+			agents.add(agent);
+		}
+		metsHdr.setAgents(agents);
+		return metsHdr;
+	}
+
+	private static Source getMetsSchema(CatalogResolver catalogResolver) throws SAXException, IOException {
+		InputSource resolvedSchema = catalogResolver.resolveEntity(null, "http://www.loc.gov/standards/mets/mets.xsd");
+		return new StreamSource(resolvedSchema.getSystemId());
+	}
+
+	private static CatalogResolver getCatalogResolver() throws IOException {
+		Enumeration<URL> resources = Mets.class.getClassLoader().getResources("catalog.xml");
+		URI[] catalogURIs = StreamSupport
+				.stream(Spliterators.spliteratorUnknownSize(resources.asIterator(), Spliterator.ORDERED), false)
+				.map(URL::toString).peek(s -> LOGGER.info("Using XML catalog: {}", s)).map(URI::create)
+				.toArray(URI[]::new);
+		return CatalogManager.catalogResolver(CatalogFeatures.defaults(), catalogURIs);
+	}
+
+	public static Map<String, DmdSec> createDmdSec(Document source) {
+		Map<String, DmdSec> dmdsecs = new HashMap<>();
+		XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:dmdSec");
+
+		for (Element section : xp.evaluate(source)) {
+			DmdSec dmdSec = new DmdSec(section.getAttributeValue("ID"));
+			dmdsecs.put(dmdSec.getId(), dmdSec);
+
+			// handle mdWrap
+			xp = getXpathExpression("mets:mdWrap");
+
+			for (Element wrap : xp.evaluate(section)) {
+				XPathExpression<Element> xmlDataXP = getXpathExpression("mets:xmlData/*");
+				Element element = xmlDataXP.evaluateFirst(wrap);
+				MdWrap mdWrap = new MdWrap(MdWrapSection.findTypeByName(wrap.getAttributeValue("MDTYPE")),
+						(Element) element.clone());
+				dmdSec.setMdWrap(mdWrap);
+			}
+
+			// handle mdRef
+			xp = getXpathExpression("mets:mdRef");
+
+			for (Element refElem : xp.evaluate(section)) {
+				LOCTYPE loctype = LOCTYPE.valueOf(refElem.getAttributeValue("LOCTYPE"));
+				String mimetype = refElem.getAttributeValue("MIMETYPE");
+				MDTYPE mdtype = MdWrapSection.findTypeByName(refElem.getAttributeValue("MDTYPE"));
+				String href = refElem.getAttributeValue("href", IMetsElement.XLINK);
+				MdRef mdRef = new MdRef(href, loctype, mimetype, mdtype, refElem.getText());
+				dmdSec.setMdRef(mdRef);
+			}
+		}
+		return dmdsecs;
+	}
+
+	public static Map<String, AmdSec> createAmdSec(Document source) {
+		Map<String, AmdSec> amdsecs = new HashMap<>();
+		XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:amdSec");
+
+		for (Element section : xp.evaluate(source)) {
+			AmdSec amdSec = new AmdSec(section.getAttributeValue("ID"));
+			amdsecs.put(amdSec.getId(), amdSec);
+
+			addOther(section, amdSec, "rightsMD");
+			addOther(section, amdSec, "digiprovMD");
+		}
+		return amdsecs;
+	}
+
+	/**
+	 * Creates the elements embedded in the mets:amdSec. Currently the mets:rightsMD
+	 * and the mets:digiprovMD sections are supported.
+	 *
+	 * @param section
+	 * @param amdSec
+	 * @param flag    one of "rightsMD" or "addRightsMd"
+	 */
+	private static void addOther(Element section, AmdSec amdSec, String flag) {
+		XPathExpression<Element> rightsMdXP = getXpathExpression("mets:" + flag);
+
+		Element flagElement = rightsMdXP.evaluateFirst(section);
+		if (flagElement != null) {
+			String id = flagElement.getAttributeValue("ID");
+			RightsMD rightsMd = new RightsMD(id);
+			amdSec.setRightsMD(rightsMd);
+
+			XPathExpression<Element> mdWrapXP = getXpathExpression("mets:mdWrap");
+
+			flagElement = mdWrapXP.evaluateFirst(flagElement);
+			if (flagElement != null) {
+				String name = flagElement.getAttributeValue("MDTYPE");
+				XPathExpression<Element> xmlDataXP = getXpathExpression("mets:xmlData/*");
+				Element element = xmlDataXP.evaluateFirst(flagElement);
+				MdWrap mdWrap = new MdWrap(MdWrapSection.findTypeByName(name), (Element) element.clone());
+				mdWrap.setOtherMdType(flagElement.getAttributeValue("OTHERMDTYPE"));
+				rightsMd.setMdWrap(mdWrap);
+			}
+		}
+	}
+
+	/**
+	 * Creates the mets:structMap TYPE="LOGICAL".
+	 *
+	 * @param source the source document
+	 * @return a new created logical struct map based on the source
+	 */
+	public static LogicalStructMap createLogicalStructMap(Document source) {
+		LogicalStructMap logicalStructMap = new LogicalStructMap();
+		XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:structMap[@TYPE='LOGICAL']/mets:div");
+
+		Element logDivContainerElem = xp.evaluateFirst(source);
+
+		LogicalDiv logDivContainer = new LogicalDiv(logDivContainerElem.getAttributeValue("ID"),
+				logDivContainerElem.getAttributeValue("TYPE"), logDivContainerElem.getAttributeValue("LABEL"),
+				logDivContainerElem.getAttributeValue("ADMID"), logDivContainerElem.getAttributeValue("DMDID"));
+
+		for (Element logSubDiv : logDivContainerElem.getChildren()) {
+			LogicalDiv lsd = new LogicalDiv(logSubDiv.getAttributeValue("ID"), logSubDiv.getAttributeValue("TYPE"),
+					logSubDiv.getAttributeValue("LABEL"));
+			logDivContainer.add(lsd);
+
+			processLogicalChildren(logSubDiv.getChildren(), lsd);
+		}
+
+		// add the div container to the struct map
+		logicalStructMap.setDivContainer(logDivContainer);
+		return logicalStructMap;
+	}
+
+	/**
+	 * @param children
+	 * @param parent
+	 */
+	private static void processLogicalChildren(List<Element> children, LogicalDiv parent) {
+		for (Element child : children) {
+			switch (child.getName()) {
+			case "fptr":
+				Fptr fptr = processFPTR(child);
+				parent.getFptrList().add(fptr);
+				break;
+			case "div":
+				LogicalDiv lsd = new LogicalDiv(child.getAttributeValue("ID"), child.getAttributeValue("TYPE"),
+						child.getAttributeValue("LABEL"));
+				parent.add(lsd);
+
+				processLogicalChildren((List<Element>) child.getChildren(), lsd);
+				break;
+			default:
+				return;
+			}
+		}
+	}
+
+	private static Fptr processFPTR(Element child) {
+		Fptr fptr = new Fptr();
+
+		String fileid = child.getAttributeValue("FILEID");
+		if (fileid != null) {
+			fptr.setFileId(fileid);
+		}
+
+		Element seq = child.getChild("seq", IMetsElement.METS);
+		if (seq != null) {
+			Seq newSEQ = new Seq();
+			fptr.getSeqList().add(newSEQ);
+
+			List<Element> seqAreaChildren = seq.getChildren("area", IMetsElement.METS);
+			for (Element area : seqAreaChildren) {
+				String fileId = area.getAttributeValue("FILEID");
+				if (fileId == null) {
+					throw new IllegalArgumentException("FILEID attribute value of mets:area must not be null");
+				}
+				String betype = area.getAttributeValue("BETYPE");
+				String begin = area.getAttributeValue("BEGIN");
+				String end = area.getAttributeValue("END");
+				newSEQ.getAreaList().add(new Area(fileId, betype, begin, end));
+			}
+		}
+		return fptr;
+	}
+
+	/**
+	 * Creates the mets:structMap TYPE="PHYSICAL".
+	 *
+	 * @param source the source document
+	 * @return a new created physical struct map based on the given source
+	 */
+	public static PhysicalStructMap createPhysicalStructMap(Document source) {
+		PhysicalStructMap structMap = new PhysicalStructMap();
+		XPathExpression<Element> xp = getXpathExpression("mets:mets/mets:structMap[@TYPE='PHYSICAL']/mets:div");
+
+		Element physDivElem = xp.evaluateFirst(source);
+		String id = physDivElem.getAttributeValue("ID");
+		String type = physDivElem.getAttributeValue("TYPE");
+
+		if (id == null || type == null) {
+			throw new IllegalArgumentException("ID and TYPE attribute of mets:div must not be null");
+		}
+		PhysicalDiv physDivContainer = new PhysicalDiv(id, type);
+		structMap.setDivContainer(physDivContainer);
+
+		for (Element subDiv : physDivElem.getChildren()) {
+			PhysicalSubDiv psd = new PhysicalSubDiv(subDiv.getAttributeValue("ID"), subDiv.getAttributeValue("TYPE"));
+
+			String orderLabel = subDiv.getAttributeValue("ORDERLABEL");
+			if (orderLabel != null) {
+				psd.setOrderLabel(orderLabel);
+			}
+
+			String contentIDs = subDiv.getAttributeValue("CONTENTIDS");
+			if (contentIDs != null) {
+				psd.setContentIds(contentIDs);
+			}
+
+			xp = getXpathExpression("./mets:fptr");
+
+			for (Element fptrElem : xp.evaluate(subDiv)) {
+				Fptr fptr = new Fptr(fptrElem.getAttributeValue("FILEID"));
+				psd.add(fptr);
+			}
+			physDivContainer.add(psd);
+		}
+		return structMap;
+	}
+
+	/**
+	 * Creates the mets:structLink section from the given source.
+	 *
+	 * @param source the source document
+	 * @return a new created struct link based on the given source
+	 */
+	public static StructLink createStuctLinks(Document source) {
+		StructLink structLink = new StructLink();
+		XPathExpression<Element> smLinksXP = getXpathExpression("mets:mets/mets:structLink/mets:smLink");
+
+		for (Element smLink : smLinksXP.evaluate(source)) {
+			String from = smLink.getAttributeValue("from", IMetsElement.XLINK);
+			String to = smLink.getAttributeValue("to", IMetsElement.XLINK);
+			if (from == null || to == null) {
+				throw new IllegalArgumentException("xlink:from and xlink:to must not be null in mets:smLink element");
+			}
+			SmLink l = new SmLink(from, to);
+			structLink.addSmLink(l);
+		}
+		return structLink;
+	}
+
+	private static XPathExpression<Element> getXpathExpression(String xpath) {
+		return XPATH_FACTORY.compile(xpath, Filters.element(), null, IMetsElement.METS);
+	}
+
+	/**
+	 * Creates the file section from the given source document.
+	 *
+	 * @param source the source document
+	 * @return a new created file section based on the given source
+	 */
+	public static FileSec createFileSec(Document source) {
+		FileSec fileSec = new FileSec();
+		XPathExpression<Element> grpXPath = getXpathExpression("mets:mets/mets:fileSec/mets:fileGrp");
+
+		for (Element aFileGroup : grpXPath.evaluate(source)) {
+			// create a fileGrp object
+			String useAttribute = aFileGroup.getAttributeValue("USE");
+			if (useAttribute == null) {
+				throw new IllegalArgumentException("USE attribute value must not be null");
+			}
+			FileGrp grp = new FileGrp(useAttribute);
+
+			// get the files to add to the file grp object
+			XPathExpression<Element> filesXP = getXpathExpression("./mets:file");
+
+			for (Element aFile : filesXP.evaluate(aFileGroup)) {
+				String id = aFile.getAttributeValue("ID");
+				String mimeType = aFile.getAttributeValue("MIMETYPE");
+				if (id == null || mimeType == null) {
+					throw new IllegalArgumentException("MIMETYPE or ID of a mets:file must not be null");
+				}
+				File f = new File(id, mimeType);
+				// create the FLocat element and add it to the file element
+				String locType = aFile.getChild("FLocat", IMetsElement.METS).getAttributeValue("LOCTYPE");
+				String href = aFile.getChild("FLocat", IMetsElement.METS).getAttributeValue("href", IMetsElement.XLINK);
+
+				if (locType == null || href == null) {
+					throw new IllegalArgumentException("LOCTYPE or xlink:href of a mets:FLocat must not be null");
+				}
+				FLocat fLoc = new FLocat(LOCTYPE.valueOf(locType), href);
+				f.setFLocat(fLoc);
+				grp.addFile(f);
+			}
+
+			// add the new created file group to the file section
+			fileSec.addFileGrp(grp);
+		}
+		return fileSec;
+	}
+
+	/**
+	 * Sets the header for this document.
+	 * 
+	 * @param metsHdr the mets header
+	 */
+	public void setMetsHdr(MetsHdr metsHdr) {
+		this.metsHdr = metsHdr;
+	}
+
+	/**
+	 * Returns the header for this mets document. Can return null if no header is
+	 * specified.
+	 * 
+	 * @return the mets header or null
+	 */
+	public MetsHdr getMetsHdr() {
+		return metsHdr;
+	}
+
+	/**
+	 * Adds the section to the mets document
+	 *
+	 * @param section the section to add
+	 * @return <code>true</code> if the section was added successfully,
+	 *         <code>false</code> otherwise
+	 */
+	public boolean addDmdSec(DmdSec section) {
+		String id = section.getId();
+		if (dmdsecs.containsKey(id)) {
+			return false;
+		}
+		dmdsecs.put(id, section);
+		return true;
+	}
+
+	/**
+	 * Removes the given MdSection from the Mets document
+	 *
+	 * @param section the section to remove
+	 */
+	public void removeDmdSec(DmdSec section) {
+		dmdsecs.remove(section.getId());
+	}
+
+	/**
+	 * Removes all dmd sections from the mets document.
+	 */
+	public void clearDmdSecs() {
+		dmdsecs.clear();
+	}
+
+	/**
+	 * Adds the section to the mets document
+	 *
+	 * @param section the section to add
+	 * @return <code>true</code> if the section was added successfully,
+	 *         <code>false</code> otherwise
+	 */
+	public boolean addAmdSec(AmdSec section) {
+		String id = section.getId();
+		if (amdsecs.containsKey(id)) {
+			return false;
+		}
+		amdsecs.put(id, section);
+		return true;
+	}
+
+	/**
+	 * Removes the given MdSection from the Mets document
+	 *
+	 * @param section the section to remove
+	 */
+	public void removeAmdSec(AmdSec section) {
+		amdsecs.remove(section.getId());
+	}
+
+	/**
+	 * Removes all amd sections from the mets document.
+	 */
+	public void clearAmdSec() {
+		amdsecs.clear();
+	}
+
+	public IStructMap getStructMap(String type) {
+		return this.structMaps.get(type);
+	}
+
+	public PhysicalStructMap getPhysicalStructMap() {
+		return (PhysicalStructMap) this.structMaps.get(PhysicalStructMap.TYPE);
+	}
+
+	public LogicalStructMap getLogicalStructMap() {
+		return (LogicalStructMap) this.structMaps.get(LogicalStructMap.TYPE);
+	}
+
+	public void addStructMap(IStructMap structMap) {
+		this.structMaps.put(structMap.getType(), structMap);
+	}
+
+	public void removeStructMap(String type) {
+		this.structMaps.remove(type);
+	}
+
+	/**
+	 * @return the structLink
+	 */
+	public StructLink getStructLink() {
+		return structLink;
+	}
+
+	/**
+	 * @param structLink the structLink to set
+	 */
+	public void setStructLink(StructLink structLink) {
+		this.structLink = structLink;
+	}
+
+	/**
+	 * @return the fileSec
+	 */
+	public FileSec getFileSec() {
+		return fileSec;
+	}
+
+	/**
+	 * @param fileSec the fileSec to set
+	 */
+	public void setFileSec(FileSec fileSec) {
+		this.fileSec = fileSec;
+	}
+
+	/**
+	 * @param id the id of the amdsec to retrieve
+	 * @return the amdsec with the given id or null if there is no such amd section
+	 */
+	public AmdSec getAmdSecById(String id) {
+		return this.amdsecs.get(id);
+	}
+
+	/**
+	 * @return all amd sections
+	 */
+	public AmdSec[] getAmdSections() {
+		return this.amdsecs.values().toArray(new AmdSec[0]);
+	}
+
+	/**
+	 * @return all dmd sections
+	 */
+	public DmdSec[] getDmdSections() {
+		return this.dmdsecs.values().toArray(new DmdSec[0]);
+	}
+
+	/**
+	 * @param id the id of the dmdsec to retrieve
+	 * @return the dmdsec with the given id or null if there is no such dmd section
+	 */
+	public DmdSec getDmdSecById(String id) {
+		return this.dmdsecs.get(id);
+	}
+
+	/**
+	 * Returns the Mets Object as {@link Document}.
+	 *
+	 * @return the mets object as jdom document
+	 */
+	public Document asDocument() {
+		Document doc = new Document();
+		doc.setRootElement(asElement());
+		return doc;
+	}
+
+	/**
+	 * Returns the Mets Object as {@link Element}
+	 *
+	 * @return the mets object as jdom element
+	 */
+	public Element asElement() {
+		Element mets = new Element("mets", IMetsElement.METS);
+		mets.addNamespaceDeclaration(IMetsElement.XSI);
+		mets.setAttribute("schemaLocation", IMetsElement.SCHEMA_LOC_METS, IMetsElement.XSI);
+
+		if (this.metsHdr != null) {
+			mets.addContent(this.metsHdr.asElement());
+		}
+		for (DmdSec dmdSec : this.dmdsecs.values()) {
+			mets.addContent(dmdSec.asElement());
+		}
+		for (AmdSec amdSec : this.amdsecs.values()) {
+			mets.addContent(amdSec.asElement());
+		}
+		if (this.getFileSec() != null) {
+			mets.addContent(this.getFileSec().asElement());
+		}
+		for (IStructMap sM : this.structMaps.values()) {
+			mets.addContent(sM.asElement());
+		}
+		if (this.getStructLink() != null) {
+			mets.addContent(this.getStructLink().asElement());
+		}
+		return mets;
+	}
+
+	/**
+	 * @param doc the document to validate against the mets schema
+	 * @return true if the document is a valid mets document false otherwise
+	 */
+	public static boolean isValid(Document doc) {
+		Validator validator = SCHEMA.newValidator();
+		try {
+			validator.validate(new JDOMSource(doc));
+			return true;
+		} catch (SAXException saxEx) {
+			LOGGER.error("Error parsing and validating mets document", saxEx);
+		} catch (IOException ioEx) {
+			LOGGER.error("Error reading input stream", ioEx);
+		}
+		return false;
+	}
+
+	/**
+	 * Validates the mets object.
+	 * 
+	 * @return <code>true</code> if the underlying mets document ist valid,
+	 *         <code>false</code> otherwise
+	 */
+	final public boolean isValid() {
+		Document doc;
+		try {
+			doc = this.asDocument();
+		} catch (Throwable t) {
+			LOGGER.error("Error occured while validating mets document", t);
+			return false;
+		}
+
+		return Mets.isValid(doc);
+	}
 
 }

--- a/src/main/java/org/mycore/mets/model/header/Agent.java
+++ b/src/main/java/org/mycore/mets/model/header/Agent.java
@@ -1,0 +1,150 @@
+package org.mycore.mets.model.header;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jdom2.Element;
+import org.mycore.mets.model.IMetsElement;
+
+/**
+ * 
+ * The &lt;agent&gt; element provides for various parties and 
+ * their roles with respect to the METS record to be documented.
+ * 
+ * @see <a href=
+ *      "http://www.loc.gov/standards/mets/docs/mets.v1-8.html#agent">agent</a>
+ * 
+ * @author Uwe Hartwig (M3ssman)
+ *
+ */
+public class Agent implements IMetsElement {
+
+	private String id;
+
+	private String role;
+
+	private String otherRole;
+
+	private String type;
+
+	private String otherType;
+
+	private Name name;
+
+	private List<Note> notes;
+
+	/**
+	 * 
+	 * Set required Attribute "ROLE" per default to "OTHER"
+	 * 
+	 */
+	public Agent() {
+		this.role = "OTHER";
+		this.notes = new ArrayList<>();
+	}
+
+	/**
+	 * 
+	 * Attribute "ROLE" is required only
+	 * 
+	 * @param role
+	 * @param name
+	 */
+	public Agent(String role, Name name) {
+		this.role = role;
+		this.name = name;
+		this.notes = new ArrayList<>();
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	public String getOtherRole() {
+		return otherRole;
+	}
+
+	public void setOtherRole(String otherRole) {
+		this.otherRole = otherRole;
+	}
+
+	public String getOtherType() {
+		return otherType;
+	}
+
+	public void setOtherType(String otherType) {
+		this.otherType = otherType;
+	}
+
+	public Name getName() {
+		return name;
+	}
+
+	public void setName(Name name) {
+		this.name = name;
+	}
+
+	public List<Note> getNotes() {
+		return notes;
+	}
+
+	public void setNotes(List<Note> notes) {
+		this.notes = notes;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.mycore.mets.model.IMetsElement#asElement()
+	 */
+	@SuppressWarnings("exports")
+	@Override
+	public Element asElement() {
+		Element agent = new Element("agent", IMetsElement.METS);
+		if (getRole() != null) {
+			agent.setAttribute("ROLE", getRole());
+		}
+		if (getOtherRole() != null) {
+			agent.setAttribute("OTHERROLE", getOtherRole());
+		}
+		if (this.getType() != null) {
+			agent.setAttribute("TYPE", this.getType());
+		}
+		if (getOtherType() != null) {
+			agent.setAttribute("OTHERTYPE", getOtherType());
+		}
+		if (getId() != null) {
+			agent.setAttribute("ID", getId());
+		}
+		if (getName() != null) {
+			agent.addContent(getName().asElement());
+		}
+		if (getNotes() != null && ! getNotes().isEmpty()) {
+			for (Note note : getNotes()) {
+				agent.addContent(note.asElement());
+			}
+		}
+		return agent;
+	}
+
+}

--- a/src/main/java/org/mycore/mets/model/header/AltRecordID.java
+++ b/src/main/java/org/mycore/mets/model/header/AltRecordID.java
@@ -1,0 +1,59 @@
+package org.mycore.mets.model.header;
+
+import org.jdom2.Element;
+import org.mycore.mets.model.IMetsElement;
+
+/**
+ * 
+ * The alternative record identifier element &lt;altRecordID&gt; 
+ * allows one to use alternative record identifier values 
+ * for the digital object represented by the METS document;
+ * the primary record identifier is stored in the OBJID 
+ * attribute in the root &lt;mets&gt; element.
+ * 
+ * @see <a href=
+ *      "http://www.loc.gov/standards/mets/docs/mets.v1-8.html#altRecordID">altRecordID</a>
+ * 
+ * @author Uwe Hartwig (M3ssman)
+ *
+ */
+public class AltRecordID implements IMetsElement {
+
+	private String id;
+
+	private String type;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.mycore.mets.model.IMetsElement#asElement()
+	 */
+	@SuppressWarnings("exports")
+	@Override
+	public Element asElement() {
+		Element altRecord = new Element("altRecordID", IMetsElement.METS);
+		if (getId() != null) {
+			altRecord.setAttribute("ID", getId());
+		}
+		if (getType() != null) {
+			altRecord.setAttribute("TYPE", this.getType());
+		}
+		return altRecord;
+	}
+}

--- a/src/main/java/org/mycore/mets/model/header/MetsHdr.java
+++ b/src/main/java/org/mycore/mets/model/header/MetsHdr.java
@@ -1,6 +1,7 @@
 package org.mycore.mets.model.header;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
@@ -50,8 +51,8 @@ public class MetsHdr implements IMetsElement {
 		this.id = null;
 		this.admId = null;
 		this.recordStatus = null;
-		this.setCreateDate(LocalDateTime.now());
-		this.setLastModDate(LocalDateTime.now());
+		this.setCreateDate(LocalDateTime.now(ZoneId.of("Europe/Paris")));
+		this.setLastModDate(LocalDateTime.now(ZoneId.of("Europe/Paris")));
 		this.agents = new ArrayList<>();
 		this.altRecordIds = new ArrayList<>();
 	}

--- a/src/main/java/org/mycore/mets/model/header/MetsHdr.java
+++ b/src/main/java/org/mycore/mets/model/header/MetsHdr.java
@@ -1,169 +1,212 @@
 package org.mycore.mets.model.header;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoField;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jdom2.Element;
 import org.mycore.mets.model.IMetsElement;
 
 /**
- * The mets header element &lt;metsHdr&gt; captures metadata about the METS document itself,
- * not the digital object the METS document encodes. Although it records a more
- * limited set of metadata, it is very similar in function and purpose to the headers
- * employed in other schema such as the Text Encoding Initiative (TEI) or in the Encoded
- * Archival Description (EAD).
+ * The mets header element &lt;metsHdr&gt; captures metadata about the METS
+ * document itself, not the digital object the METS document encodes. Although
+ * it records a more limited set of metadata, it is very similar in function and
+ * purpose to the headers employed in other schema such as the Text Encoding
+ * Initiative (TEI) or in the Encoded Archival Description (EAD).
  * 
- * @see <a href="http://www.loc.gov/standards/mets/docs/mets.v1-9.html#metsHdr">metsHdr</a>
+ * @see <a href=
+ *      "http://www.loc.gov/standards/mets/docs/mets.v1-9.html#metsHdr">metsHdr</a>
  * @author Matthias Eichner
  */
 public class MetsHdr implements IMetsElement {
 
-    private String id;
+	private String id;
 
-    private String admId;
+	private String admId;
 
-    private Instant createDate;
+	private LocalDateTime createDate;
 
-    private Instant lastModDate;
+	private LocalDateTime lastModDate;
 
-    private String recordStatus;
+	private String recordStatus;
 
-    /**
-     * Creates a new &lt;metsHdr&gt; object.
-     * 
-     */
-    public MetsHdr() {
-        this.id = null;
-        this.admId = null;
-        this.recordStatus = null;
-        this.setCreateDate(Instant.now());
-        this.setLastModDate(Instant.now());
-    }
+	private List<Agent> agents;
 
-    @Override
-    public Element asElement() {
-        Element metsHdr = new Element("metsHdr", IMetsElement.METS);
-        if (this.id != null) {
-            metsHdr.setAttribute("ID", this.id);
-        }
-        if (this.admId != null) {
-            metsHdr.setAttribute("ADMID", this.admId);
-        }
-        if (this.createDate != null) {
-            metsHdr.setAttribute("CREATEDATE", DateTimeFormatter.ISO_INSTANT.format(this.createDate));
-        }
-        if (this.lastModDate != null) {
-            metsHdr.setAttribute("LASTMODDATE", DateTimeFormatter.ISO_INSTANT.format(this.lastModDate));
-        }
-        if (this.recordStatus != null) {
-            metsHdr.setAttribute("RECORDSTATUS", this.recordStatus);
-        }
-        return metsHdr;
-    }
+	private List<AltRecordID> altRecordIds;
 
-    /**
-     * This attribute uniquely identifies the element within the METS document,
-     * and would allow the element to be referenced unambiguously from another element or
-     * document via an IDREF or an XPTR. For more information on using ID attributes for
-     * internal and external linking see Chapter 4 of the METS Primer.
-     * 
-     * @return the id
-     */
-    public String getId() {
-        return id;
-    }
+	public static final DateTimeFormatter DT_FORMATTER = new DateTimeFormatterBuilder()
+			.appendPattern("uuuu-MM-dd")
+			.appendLiteral('T')
+			.appendPattern("HH:mm:ss")
+			.toFormatter();
 
-    /**
-     * This attribute uniquely identifies the element within the METS document,
-     * and would allow the element to be referenced unambiguously from another element or
-     * document via an IDREF or an XPTR. For more information on using ID attributes for
-     * internal and external linking see Chapter 4 of the METS Primer.
-     * 
-     * @param id the new id
-     */
-    public void setId(String id) {
-        this.id = id;
-    }
+	/**
+	 * Creates a new &lt;metsHdr&gt; object.
+	 * 
+	 */
+	public MetsHdr() {
+		this.id = null;
+		this.admId = null;
+		this.recordStatus = null;
+		this.setCreateDate(LocalDateTime.now());
+		this.setLastModDate(LocalDateTime.now());
+		this.agents = new ArrayList<>();
+		this.altRecordIds = new ArrayList<>();
+	}
 
-    /**
-     * Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;,
-     * &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document
-     * that contain administrative metadata pertaining to the METS document itself. For
-     * more information on using METS IDREFS and IDREF type attributes for internal
-     * linking, see Chapter 4 of the METS Primer.
-     * 
-     * @return the adm identifier
-     */
-    public String getAdmId() {
-        return admId;
-    }
+	@SuppressWarnings("exports")
+	@Override
+	public Element asElement() {
+		Element metsHdr = new Element("metsHdr", IMetsElement.METS);
+		if (this.id != null) {
+			metsHdr.setAttribute("ID", this.id);
+		}
+		if (this.admId != null) {
+			metsHdr.setAttribute("ADMID", this.admId);
+		}
+		if (this.createDate != null) {
+			String createDate = DT_FORMATTER.format(this.createDate);
+			metsHdr.setAttribute("CREATEDATE", createDate);
+		}
+		if (this.lastModDate != null) {
+			String modDate = DT_FORMATTER.format(this.lastModDate);
+			metsHdr.setAttribute("LASTMODDATE", modDate);
+		}
+		if (this.recordStatus != null) {
+			metsHdr.setAttribute("RECORDSTATUS", this.recordStatus);
+		}
+		if (this.agents != null && !this.agents.isEmpty()) {
+			for (Agent agent : this.agents) {
+				metsHdr.addContent(agent.asElement());
+			}
+		}
+		return metsHdr;
+	}
 
-    /**
-     * Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;,
-     * &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt; of the METS document
-     * that contain administrative metadata pertaining to the METS document itself. For
-     * more information on using METS IDREFS and IDREF type attributes for internal
-     * linking, see Chapter 4 of the METS Primer.
-     * 
-     * @param admId the new adm identifier
-     */
-    public void setAdmId(String admId) {
-        this.admId = admId;
-    }
+	/**
+	 * This attribute uniquely identifies the element within the METS document, and
+	 * would allow the element to be referenced unambiguously from another element
+	 * or document via an IDREF or an XPTR. For more information on using ID
+	 * attributes for internal and external linking see Chapter 4 of the METS
+	 * Primer.
+	 * 
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
 
-    /**
-     * Records the date/time the METS document was created.
-     * 
-     * @return mets document creation date time
-     */
-    public Instant getCreateDate() {
-        return createDate;
-    }
+	/**
+	 * This attribute uniquely identifies the element within the METS document, and
+	 * would allow the element to be referenced unambiguously from another element
+	 * or document via an IDREF or an XPTR. For more information on using ID
+	 * attributes for internal and external linking see Chapter 4 of the METS
+	 * Primer.
+	 * 
+	 * @param id the new id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
 
-    /**
-     * Records the date/time the METS document was created.
-     * 
-     * @param createDate new creation date
-     */
-    public void setCreateDate(Instant createDate) {
-        this.createDate = Instant.ofEpochMilli(createDate.toEpochMilli()).with(ChronoField.MILLI_OF_SECOND, 0);
-    }
+	/**
+	 * Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;,
+	 * &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt;
+	 * of the METS document that contain administrative metadata pertaining to the
+	 * METS document itself. For more information on using METS IDREFS and IDREF
+	 * type attributes for internal linking, see Chapter 4 of the METS Primer.
+	 * 
+	 * @return the adm identifier
+	 */
+	public String getAdmId() {
+		return admId;
+	}
 
-    /**
-     * Is used to indicate the date/time the METS document was last modified.
-     * 
-     * @return mets document modified date
-     */
-    public Instant getLastModDate() {
-        return lastModDate;
-    }
+	/**
+	 * Contains the ID attribute values of the &lt;techMD&gt;, &lt;sourceMD&gt;,
+	 * &lt;rightsMD&gt; and/or &lt;digiprovMD&gt; elements within the &lt;amdSec&gt;
+	 * of the METS document that contain administrative metadata pertaining to the
+	 * METS document itself. For more information on using METS IDREFS and IDREF
+	 * type attributes for internal linking, see Chapter 4 of the METS Primer.
+	 * 
+	 * @param admId the new adm identifier
+	 */
+	public void setAdmId(String admId) {
+		this.admId = admId;
+	}
 
-    /**
-     * Is used to indicate the date/time the METS document was last modified.
-     * 
-     * @param lastModDate new modified date
-     */
-    public void setLastModDate(Instant lastModDate) {
-        this.lastModDate = Instant.ofEpochMilli(lastModDate.toEpochMilli()).with(ChronoField.MILLI_OF_SECOND, 0);
-    }
+	/**
+	 * Records the date/time the METS document was created.
+	 * 
+	 * @return mets document creation date time
+	 */
+	public LocalDateTime getCreateDate() {
+		return createDate;
+	}
 
-    /**
-     * Specifies the status of the METS document. It is used for internal processing purposes.
-     * 
-     * @return status of the mets document
-     */
-    public String getRecordStatus() {
-        return recordStatus;
-    }
+	/**
+	 * Records the date/time the METS document was created.
+	 * 
+	 * @param createDate new creation date
+	 */
+	public void setCreateDate(LocalDateTime createDate) {
+		this.createDate = createDate;
+	}
 
-    /**
-     * Specifies the status of the METS document. It is used for internal processing purposes.
-     * 
-     * @param recordStatus status of this mets document
-     */
-    public void setRecordStatus(String recordStatus) {
-        this.recordStatus = recordStatus;
-    }
+	/**
+	 * Is used to indicate the date/time the METS document was last modified.
+	 * 
+	 * @return mets document modified date
+	 */
+	public LocalDateTime getLastModDate() {
+		return lastModDate;
+	}
+
+	/**
+	 * Is used to indicate the date/time the METS document was last modified.
+	 * 
+	 * @param lastModDate new modified date
+	 */
+	public void setLastModDate(LocalDateTime lastModDate) {
+		this.lastModDate = lastModDate;
+	}
+
+	/**
+	 * Specifies the status of the METS document. It is used for internal processing
+	 * purposes.
+	 * 
+	 * @return status of the mets document
+	 */
+	public String getRecordStatus() {
+		return recordStatus;
+	}
+
+	/**
+	 * Specifies the status of the METS document. It is used for internal processing
+	 * purposes.
+	 * 
+	 * @param recordStatus status of this mets document
+	 */
+	public void setRecordStatus(String recordStatus) {
+		this.recordStatus = recordStatus;
+	}
+
+	public List<Agent> getAgents() {
+		return agents;
+	}
+
+	public void setAgents(List<Agent> agents) {
+		this.agents = agents;
+	}
+
+	public List<AltRecordID> getAltRecordIds() {
+		return altRecordIds;
+	}
+
+	public void setAltRecordIds(List<AltRecordID> altRecordIds) {
+		this.altRecordIds = altRecordIds;
+	}
 
 }

--- a/src/main/java/org/mycore/mets/model/header/Name.java
+++ b/src/main/java/org/mycore/mets/model/header/Name.java
@@ -1,0 +1,50 @@
+package org.mycore.mets.model.header;
+
+import org.jdom2.Element;
+import org.mycore.mets.model.IMetsElement;
+
+/**
+ * The &lt;name&gt; element can be used to record the 
+ * full name of the document agent.
+ * 
+ * @see <a href=
+ *      "http://www.loc.gov/standards/mets/docs/mets.v1-8.html#name">name</a>
+ * 
+ * @author Uwe Hartwig (M3ssman)
+ *
+ */
+public class Name implements IMetsElement {
+
+	private String text;
+
+	public Name() {
+	}
+
+	public Name(String text) {
+		this.text = text;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.mycore.mets.model.IMetsElement#asElement()
+	 */
+	@SuppressWarnings("exports")
+	@Override
+	public Element asElement() {
+		Element name = new Element("name", IMetsElement.METS);
+		if (getText() != null) {
+			name.setText(getText());
+		}
+		return name;
+	}
+
+}

--- a/src/main/java/org/mycore/mets/model/header/Note.java
+++ b/src/main/java/org/mycore/mets/model/header/Note.java
@@ -1,0 +1,52 @@
+package org.mycore.mets.model.header;
+
+import org.jdom2.Element;
+import org.mycore.mets.model.IMetsElement;
+
+/**
+ * The &lt;note&gt; element can be used to record any 
+ * additional information regarding the agent's activities 
+ * with respect to the METS document. 
+ * 
+ * @see <a href=
+ *      "http://www.loc.gov/standards/mets/docs/mets.v1-8.html#note">metsHdr</a>
+ * 
+ * element can be used to
+ * @author Uwe Hartwig (M3ssman)
+ *
+ */
+public class Note implements IMetsElement {
+
+	private String text;
+
+	public Note() {
+	}
+
+	public Note(String text) {
+		this.text = text;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.mycore.mets.model.IMetsElement#asElement()
+	 */
+	@SuppressWarnings("exports")
+	@Override
+	public Element asElement() {
+		Element note = new Element("note", IMetsElement.METS);
+		if (getText() != null) {
+			note.setText(getText());
+		}
+		return note;
+	}
+
+}

--- a/src/test/java/org/mycore/mets/model/MetsProcessResourceTest.java
+++ b/src/test/java/org/mycore/mets/model/MetsProcessResourceTest.java
@@ -1,0 +1,136 @@
+package org.mycore.mets.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mycore.mets.model.header.Agent;
+import org.mycore.mets.model.header.MetsHdr;
+import org.mycore.mets.model.header.Name;
+import org.mycore.mets.model.header.Note;
+
+/**
+ * 
+ * @author Uwe Hartwig (M3ssman)
+ *
+ */
+public class MetsProcessResourceTest {
+
+	@ClassRule
+	@SuppressWarnings("exports")
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
+	static String sourcePath = "src/test/resources/urn:nbn:de:gbv:3:3-21437.xml";
+
+	static Path targetPath;
+
+	static Mets mets;
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		
+		targetPath = Path.of(tempDir.getRoot().getAbsolutePath(), "mets.xml");
+		Path absPath = Path.of(sourcePath).toAbsolutePath(); 
+		Files.copy(absPath, targetPath);
+		mets = extractMets(targetPath.toString());
+	}
+
+	private static Mets extractMets(String targetPath) throws JDOMException, IOException {
+		File f = new File(targetPath);
+		SAXBuilder builder = new SAXBuilder();
+		Document document = builder.build(f);
+		return new Mets(document);
+	}
+
+	@Test
+	public void testMetsDefaultStructureElementsPresent() {
+		assertNotNull(mets);
+		assertNotNull(mets.getAmdSections());
+		assertEquals(1, mets.getAmdSections().length);
+		assertNotNull(mets.getDmdSections());
+		assertEquals(1, mets.getDmdSections().length);
+		assertNotNull(mets.getFileSec());
+		assertEquals(5, mets.getFileSec().getFileGroups().size());
+		assertNotNull(mets.getLogicalStructMap());
+		assertNotNull(mets.getLogicalStructMap().getDivContainer());
+		assertNotNull(mets.getLogicalStructMap().getDivContainer().getChildren());
+		assertEquals(3, mets.getLogicalStructMap().getDivContainer().getChildren().size());
+		assertNotNull(mets.getPhysicalStructMap());
+		assertNotNull(mets.getPhysicalStructMap().getDivContainer());
+		assertNotNull(mets.getPhysicalStructMap().getDivContainer().getChildren());
+		assertEquals(4, mets.getPhysicalStructMap().getDivContainer().getChildren().size());
+		assertNotNull(mets.getStructLink());
+		assertNotNull(mets.getStructLink().getSmLinks());
+		assertEquals(4, mets.getStructLink().getSmLinks().size());
+	}
+
+	@Test
+	public void testOriginalMetsHdrPresent() {
+		assertNotNull(mets.getMetsHdr());
+	}
+
+	@Test
+	public void testOrignalHetsHdrAgentsPresent() {
+		MetsHdr metsHdr = mets.getMetsHdr();
+		assertNotNull(metsHdr.getAgents());
+		assertEquals(4, metsHdr.getAgents().size());
+	}
+
+	@Test
+	public void testOriginalHetsHdrAgentDetails() {
+		MetsHdr metsHdr = mets.getMetsHdr();
+		assertNotNull(metsHdr.getAgents());
+		assertNotNull(metsHdr.getAgents().get(0).getName());
+		assertEquals("vls/2.12.1", metsHdr.getAgents().get(0).getName().getText());
+		assertNotNull(metsHdr.getAgents().get(1).getName());
+		assertEquals("ulbhal-hspe", metsHdr.getAgents().get(1).getName().getText());
+		assertNotNull(metsHdr.getAgents().get(2).getName());
+		assertEquals("digital.bibliothek.uni-halle.de/hd", metsHdr.getAgents().get(2).getName().getText());
+		assertNotNull(metsHdr.getAgents().get(3).getName());
+		assertEquals("vd", metsHdr.getAgents().get(3).getName().getText());
+	}
+
+	@Test
+	public void testAddNewMetsHdrAgent() throws Exception {
+		MetsHdr metsHdr = mets.getMetsHdr();
+		assertEquals(4, metsHdr.getAgents().size());
+
+		// act
+		Agent agent = new Agent("OTHER", new Name("digitalDerivans"));
+		agent.setNotes(List.of(new Note("created for test purposes")));
+		metsHdr.getAgents().add(agent);
+		String now = MetsHdr.DT_FORMATTER.format(LocalDateTime.now());
+		metsHdr.setLastModDate(LocalDateTime.parse(now));
+
+		// assert
+		assertEquals(5, metsHdr.getAgents().size());
+		
+        try (OutputStream metsOut = Files.newOutputStream(targetPath)) {
+            XMLOutputter xout = new XMLOutputter(Format.getPrettyFormat());
+            xout.output(mets.asDocument(), metsOut);
+        } 
+		
+		// re-act: check datetime serialization
+		Mets mets = extractMets(targetPath.toString());
+		assertEquals(5, mets.getMetsHdr().getAgents().size());
+		String serializedLastModifiedDate = MetsHdr.DT_FORMATTER.format(mets.getMetsHdr().getLastModDate());
+		assertEquals(now, serializedLastModifiedDate);
+	}
+
+}

--- a/src/test/resources/urn:nbn:de:gbv:3:3-21437.xml
+++ b/src/test/resources/urn:nbn:de:gbv:3:3-21437.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:mods="http://www.loc.gov/mods/v3"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:vls="http://semantics.de/vls" 
+    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd" OBJID="2" LABEL="Inhouse-Digitalisierung">
+    <mets:metsHdr CREATEDATE="2020-10-10T10:20:09">
+        <mets:agent TYPE="OTHER" ROLE="OTHER" OTHERTYPE="SOFTWARE">
+            <mets:name>vls/2.12.1</mets:name>
+        </mets:agent>
+        <mets:agent TYPE="OTHER" ROLE="OTHER" OTHERTYPE="INSTANCE">
+            <mets:name>ulbhal-hspe</mets:name>
+        </mets:agent>
+        <mets:agent TYPE="OTHER" ROLE="OTHER" OTHERTYPE="REPOSITORY">
+            <mets:name>digital.bibliothek.uni-halle.de/hd</mets:name>
+        </mets:agent>
+        <mets:agent TYPE="OTHER" ROLE="OTHER" OTHERTYPE="BUILDER">
+            <mets:name>vd</mets:name>
+        </mets:agent>
+    </mets:metsHdr>
+    <mets:dmdSec ID="md737429">
+        <mets:mdWrap MIMETYPE="text/xml" MDTYPE="MODS">
+            <mets:xmlData>
+                <mods:mods xmlns:vlz="http://visuallibrary.net/vlz/1.0/" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+                    <mods:titleInfo>
+                        <mods:title>Ode In Solemni Panegyri Avgvstissimo Ac Potentissimo Monarchae Et Domino, Christiano VI. Daniae, Norvegiae .. Regi ... D. VI. Ivnii MDCCXXXI. In Celeberrima Lipsiensivm Academia Habita Concentibvs Mvsicis Decantata</mods:title>
+                    </mods:titleInfo>
+                    <mods:name type="personal" authority="gnd" authorityURI="http://d-nb.info/gnd/" valueURI="http://d-nb.info/gnd/103769544">
+                        <mods:namePart>Brühl, Johann Benjamin</mods:namePart>
+                        <mods:namePart type="given">Johann Benjamin</mods:namePart>
+                        <mods:namePart type="family">Brühl</mods:namePart>
+                        <mods:namePart type="date">1691-1763</mods:namePart>
+                        <mods:role>
+                            <mods:roleTerm type="code" authority="marcrelator">ctb</mods:roleTerm>
+                            <mods:roleTerm type="text">BeiträgerIn k.</mods:roleTerm>
+                        </mods:role>
+                    </mods:name>
+                    <mods:name type="personal" authority="gnd" authorityURI="http://d-nb.info/gnd/" valueURI="http://d-nb.info/gnd/11897436X">
+                        <mods:namePart>Christian &lt;VI., Dänemark, König&gt;</mods:namePart>
+                        <mods:namePart type="date">1699-1746</mods:namePart>
+                        <mods:role>
+                            <mods:roleTerm type="code" authority="marcrelator">oth</mods:roleTerm>
+                            <mods:roleTerm type="text">ErwähnteR</mods:roleTerm>
+                        </mods:role>
+                    </mods:name>
+                    <mods:name type="personal" authority="gnd" authorityURI="http://d-nb.info/gnd/" valueURI="http://d-nb.info/gnd/1037332830">
+                        <mods:namePart>Officina Langenhemia</mods:namePart>
+                        <mods:namePart type="family">Officina Langenhemia</mods:namePart>
+                        <mods:role>
+                            <mods:roleTerm type="code" authority="marcrelator">pbl</mods:roleTerm>
+                            <mods:roleTerm type="text">Verl.</mods:roleTerm>
+                        </mods:role>
+                    </mods:name>
+                    <mods:name type="personal" authority="gnd" authorityURI="http://d-nb.info/gnd/" valueURI="http://d-nb.info/gnd/1037496515">
+                        <mods:namePart>Langenheim, Johann Christian</mods:namePart>
+                        <mods:namePart type="given">Johann Christian</mods:namePart>
+                        <mods:namePart type="family">Langenheim</mods:namePart>
+                        <mods:namePart type="date">1691-1764</mods:namePart>
+                        <mods:role>
+                            <mods:roleTerm type="code" authority="marcrelator">pbl</mods:roleTerm>
+                            <mods:roleTerm type="text">Verl.</mods:roleTerm>
+                        </mods:role>
+                    </mods:name>
+                    <mods:typeOfResource>text</mods:typeOfResource>
+                    <mods:genre authority="aad">Hochschulschrift</mods:genre>
+                    <mods:genre authority="aad">Gelegenheitsschrift</mods:genre>
+                    <mods:originInfo eventType="publication">
+                        <mods:place>
+                            <mods:placeTerm type="text">Lipsiae</mods:placeTerm>
+                        </mods:place>
+                        <mods:publisher>Literis Io. Christiani Langenhemii</mods:publisher>
+                        <mods:dateIssued encoding="w3cdtf" keyDate="yes">1731</mods:dateIssued>
+                        <mods:issuance>monographic</mods:issuance>
+                    </mods:originInfo>
+                    <mods:originInfo>
+                        <mods:place>
+                            <mods:placeTerm type="text">Halle, Saale</mods:placeTerm>
+                        </mods:place>
+                        <mods:publisher>Universitäts- und Landesbibliothek Sachsen-Anhalt</mods:publisher>
+                        <mods:dateIssued>2010</mods:dateIssued>
+                        <mods:edition>[Electronic ed.]</mods:edition>
+                    </mods:originInfo>
+                    <mods:language>
+                        <mods:languageTerm authority="iso639-2b" type="code">lat</mods:languageTerm>
+                    </mods:language>
+                    <mods:physicalDescription>
+                        <mods:extent>[2] Bl. ; 2°</mods:extent>
+                        <mods:note>1 Ill. (Kupferst.)</mods:note>
+                    </mods:physicalDescription>
+                    <mods:note>Vorlageform des Erscheinungsvermerks: Lipsiae Literis Io. Christiani Langenhemii.</mods:note>
+                    <mods:subject authority="gnd" authorityURI="http://d-nb.info/gnd/" valueURI="http://d-nb.info/gnd/4035206-7">
+                        <mods:geographic>Leipzig</mods:geographic>
+                    </mods:subject>
+                    <mods:identifier type="vd18">10787747</mods:identifier>
+                    <mods:identifier type="gbv">191092622</mods:identifier>
+                    <mods:identifier type="urn">urn:nbn:de:gbv:3:3-21437</mods:identifier>
+                    <mods:location>
+                        <mods:physicalLocation authority="local library code">65</mods:physicalLocation>
+                        <mods:holdingSimple>
+                            <mods:copyInformation>
+                                <mods:shelfLocator>Pon IIn 6550, FK (2)</mods:shelfLocator>
+                                <mods:note>digitized copy</mods:note>
+                            </mods:copyInformation>
+                        </mods:holdingSimple>
+                    </mods:location>
+                    <mods:location>
+                        <mods:physicalLocation authority="local library code">72</mods:physicalLocation>
+                        <mods:shelfLocator>Gm-A 10079</mods:shelfLocator>
+                    </mods:location>
+                    <mods:extension>
+                        <zvdd:zvddWrap xmlns:zvdd="http://zvdd.gdz-cms.de/">
+                            <zvdd:titleWord>augustissimo 6. Iunii Juni 1731 Lipsiensium concentibus musicis</zvdd:titleWord>
+                        </zvdd:zvddWrap>
+                        <vlz:externalType recordSyntax="pica" code="Aa"/>
+                        <vlz:info version="1"/>
+                    </mods:extension>
+                    <mods:recordInfo>
+                        <mods:recordCreationDate encoding="marc">10-01-96</mods:recordCreationDate>
+                        <mods:recordChangeDate encoding="marc">20-07-20</mods:recordChangeDate>
+                        <mods:recordIdentifier source="ulbhaldod">191092622</mods:recordIdentifier>
+                        <mods:descriptionStandard>rak</mods:descriptionStandard>
+                    </mods:recordInfo>
+                </mods:mods>
+            </mets:xmlData>
+        </mets:mdWrap>
+    </mets:dmdSec>
+    <mets:amdSec ID="amd737429">
+        <mets:rightsMD ID="rights737429">
+            <mets:mdWrap MIMETYPE="text/xml" MDTYPE="OTHER" OTHERMDTYPE="DVRIGHTS">
+                <mets:xmlData>
+                    <dv:rights xmlns:dv="http://dfg-viewer.de/">
+                        <dv:ownerLogo>http://digital.bibliothek.uni-halle.de/hd/domainresource/static/graphics/connectors/viewerLogo.gif</dv:ownerLogo>
+                        <dv:owner>Universitäts- und Landesbibliothek Sachsen-Anhalt</dv:owner>
+                        <dv:ownerSiteURL>http://www.bibliothek.uni-halle.de</dv:ownerSiteURL>
+                    </dv:rights>
+                </mets:xmlData>
+            </mets:mdWrap>
+        </mets:rightsMD>
+        <mets:digiprovMD ID="digiprov737429">
+            <mets:mdWrap MIMETYPE="text/xml" MDTYPE="OTHER" OTHERMDTYPE="DVLINKS">
+                <mets:xmlData>
+                    <dv:links xmlns:dv="http://dfg-viewer.de/">
+                        <dv:reference>http://opac.bibliothek.uni-halle.de/DB=1/CLK?IKT=12&amp;TRM=191092622</dv:reference>
+                        <dv:presentation>http://digital.bibliothek.uni-halle.de/hd/id/737429</dv:presentation>
+                    </dv:links>
+                </mets:xmlData>
+            </mets:mdWrap>
+        </mets:digiprovMD>
+    </mets:amdSec>
+    <mets:fileSec>
+        <mets:fileGrp USE="DOWNLOAD">
+            <mets:file MIMETYPE="application/pdf" CHECKSUM="99d8d65fde15a5d2a9cd14b3fa228b78c2449ec6" SIZE="1156208" CHECKSUMTYPE="SHA-1" CREATED="2013-05-22T16:11:11" ID="PDF_737429">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/pdf/737429" LOCTYPE="URL"/>
+            </mets:file>
+        </mets:fileGrp>
+        <mets:fileGrp USE="DEFAULT">
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_DEFAULT_737434">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1000/737434" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_DEFAULT_737436">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1000/737436" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_DEFAULT_737437">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1000/737437" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:36" ID="IMG_DEFAULT_737438">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1000/737438" LOCTYPE="URL"/>
+            </mets:file>
+        </mets:fileGrp>
+        <mets:fileGrp USE="THUMBS">
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_THUMBS_737434">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/128/737434" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_THUMBS_737436">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/128/737436" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_THUMBS_737437">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/128/737437" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:36" ID="IMG_THUMBS_737438">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/128/737438" LOCTYPE="URL"/>
+            </mets:file>
+        </mets:fileGrp>
+        <mets:fileGrp USE="MIN">
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MIN_737434">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/600/737434" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MIN_737436">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/600/737436" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MIN_737437">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/600/737437" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:36" ID="IMG_MIN_737438">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/600/737438" LOCTYPE="URL"/>
+            </mets:file>
+        </mets:fileGrp>
+        <mets:fileGrp USE="MAX">
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MAX_737434">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1504/737434" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MAX_737436">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1504/737436" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:35" ID="IMG_MAX_737437">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1504/737437" LOCTYPE="URL"/>
+            </mets:file>
+            <mets:file MIMETYPE="image/jpeg" CREATED="2010-10-20T10:15:36" ID="IMG_MAX_737438">
+                <mets:FLocat xlink:href="http://digital.bibliothek.uni-halle.de/hd/download/webcache/1504/737438" LOCTYPE="URL"/>
+            </mets:file>
+        </mets:fileGrp>
+    </mets:fileSec>
+    <mets:structMap TYPE="PHYSICAL">
+        <mets:div TYPE="physSequence" ID="physroot">
+            <mets:div ID="phys737434" TYPE="page" LABEL="[Seite 2]" CONTENTIDS="urn:nbn:de:gbv:3:3-21437-p0001-0" ORDER="1">
+                <mets:fptr FILEID="IMG_DEFAULT_737434"/>
+                <mets:fptr FILEID="IMG_THUMBS_737434"/>
+                <mets:fptr FILEID="IMG_MIN_737434"/>
+                <mets:fptr FILEID="IMG_MAX_737434"/>
+            </mets:div>
+            <mets:div ID="phys737436" TYPE="page" LABEL="[Seite 3]" CONTENTIDS="urn:nbn:de:gbv:3:3-21437-p0002-5" ORDER="2">
+                <mets:fptr FILEID="IMG_DEFAULT_737436"/>
+                <mets:fptr FILEID="IMG_THUMBS_737436"/>
+                <mets:fptr FILEID="IMG_MIN_737436"/>
+                <mets:fptr FILEID="IMG_MAX_737436"/>
+            </mets:div>
+            <mets:div ID="phys737437" TYPE="page" LABEL="[Seite 4]" CONTENTIDS="urn:nbn:de:gbv:3:3-21437-p0003-1" ORDER="3">
+                <mets:fptr FILEID="IMG_DEFAULT_737437"/>
+                <mets:fptr FILEID="IMG_THUMBS_737437"/>
+                <mets:fptr FILEID="IMG_MIN_737437"/>
+                <mets:fptr FILEID="IMG_MAX_737437"/>
+            </mets:div>
+            <mets:div ID="phys737438" TYPE="page" LABEL="[Seite 5]" CONTENTIDS="urn:nbn:de:gbv:3:3-21437-p0004-6" ORDER="4">
+                <mets:fptr FILEID="IMG_DEFAULT_737438"/>
+                <mets:fptr FILEID="IMG_THUMBS_737438"/>
+                <mets:fptr FILEID="IMG_MIN_737438"/>
+                <mets:fptr FILEID="IMG_MAX_737438"/>
+            </mets:div>
+        </mets:div>
+    </mets:structMap>
+    <mets:structMap TYPE="LOGICAL">
+        <mets:div ID="log737429" DMDID="md737429" ADMID="amd737429" TYPE="monograph" LABEL="Ode In Solemni Panegyri Avgvstissimo Ac Potentissimo Monarchae Et Domino, Christiano VI. Daniae, Norvegiae .. Regi ... D. VI. Ivnii MDCCXXXI. In Celeberrima Lipsiensivm Academia Habita Concentibvs Mv" ORDER="1" CONTENTIDS="urn:nbn:de:gbv:3:3-21437">
+            <mets:mptr LOCTYPE="URL" xlink:href="http://digital.bibliothek.uni-halle.de/hd/oai/?verb=GetRecord&amp;metadataPrefix=mets&amp;identifier=737429"/>
+            <mets:fptr FILEID="PDF_737429"/>
+            <mets:div ID="log737433" TYPE="title_page" LABEL="Titelblatt" ORDER="1"/>
+            <mets:div ID="log737435" TYPE="verse" LABEL="[Ode]" ORDER="2"/>
+        </mets:div>
+    </mets:structMap>
+    <mets:structLink>
+        <mets:smLink xlink:from="log737433" xlink:to="phys737434"/>
+        <mets:smLink xlink:from="log737435" xlink:to="phys737436"/>
+        <mets:smLink xlink:from="log737435" xlink:to="phys737437"/>
+        <mets:smLink xlink:from="log737435" xlink:to="phys737438"/>
+    </mets:structLink>
+</mets:mets>


### PR DESCRIPTION
Hello,

as an user I really like your OOP-approach with METS/MODS.
Now I'd like to contribute some additional functionality regarding `metsHdr`-section that I do require for working with the `mets-model`-library in the context of mass-digitalization at the ULB. It consists of several extensions to the `metsHdr`-section that were lacking. This forced me to implement some rather hacky stuff to get around this limitation but I guess the proper way is to have these functionalities included in your nice library itself. 

I needed to alter the existing `metsHdr` date handling, since I did get it to work properly at de-serialization with the previous `Instant`-types. Maybe you can come up with a better idea to handle this I'm looking forward!

Unfortunately it can't be merged out of the box since it is based on the latest published version (tag 2.0), which is not the one the master is even with.


